### PR TITLE
Don't limit to node less than 0.11.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "url": "https://github.com/Bartvds/joi-assert/issues"
   },
   "engines": {
-    "node": ">= 0.10.0 <= 0.11.0"
+    "node": ">= 0.10.0"
   },
   "main": "./index.js",
   "scripts": {


### PR DESCRIPTION
This is causing warning such as

``` sh
npm WARN engine joi-assert@0.0.3: wanted: {"node":">= 0.10.0 <= 0.11.0"} (current: {"node":"0.12.0","npm":"2.5.1"})
```
